### PR TITLE
Add Prometheus metrics for errors and cycle time

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,13 +41,7 @@ async def startup_event():
 
     interval = int(os.environ.get("PROCESS_INTERVAL", 300))
 
-    async def periodic():
-        while True:
-            logs = await core.process_logs()
-            await core.analyze(logs)
-            await asyncio.sleep(interval)
-
-    asyncio.create_task(periodic())
+    asyncio.create_task(core.periodic_worker(interval))
 
 
 @app.get("/metrics")

--- a/threat_hunter/core/gemini.py
+++ b/threat_hunter/core/gemini.py
@@ -74,6 +74,8 @@ class Gemini:
             )
             return resp.text
         except Exception as e:
+            if "429" in str(e):
+                await self.metrics.increment_429s(model)
             logger.error("Gemini API error: %s", e)
             self.rotate()
             return ""

--- a/threat_hunter/core/metrics.py
+++ b/threat_hunter/core/metrics.py
@@ -7,6 +7,8 @@ class MetricsCollector:
     def __init__(self):
         self.gemini_requests = defaultdict(int)
         self.gemini_tokens = defaultdict(lambda: defaultdict(int))
+        self.gemini_429 = defaultdict(int)
+        self.worker_cycle_seconds = 0.0
         self.lock = asyncio.Lock()
 
     async def inc_requests(self, model: str):
@@ -16,6 +18,14 @@ class MetricsCollector:
     async def add_tokens(self, model: str, direction: str, tokens: int):
         async with self.lock:
             self.gemini_tokens[model][direction] += tokens
+
+    async def increment_429s(self, model: str):
+        async with self.lock:
+            self.gemini_429[model] += 1
+
+    async def set_cycle_time(self, seconds: float):
+        async with self.lock:
+            self.worker_cycle_seconds = seconds
 
     async def render(self) -> str:
         async with self.lock:
@@ -29,4 +39,9 @@ class MetricsCollector:
                     lines.append(
                         f"gemini_tokens_total{{model=\"{model}\",direction=\"{direction}\"}} {value}"
                     )
+            for model, value in self.gemini_429.items():
+                lines.append(
+                    f"gemini_429_total{{model=\"{model}\"}} {value}"
+                )
+            lines.append(f"worker_cycle_seconds {self.worker_cycle_seconds}")
             return "\n".join(lines) + "\n"

--- a/threat_hunter/core/threat_hunter_core.py
+++ b/threat_hunter/core/threat_hunter_core.py
@@ -124,3 +124,15 @@ class ThreatHunterCore:
         self.issues = [i for i in self.issues if i.get("id") != issue_id]
         self.ignored.add(issue_id)
         self._save_state()
+
+    async def periodic_worker(self, interval: int) -> None:
+        """Continuously process logs and analyze them at a fixed interval."""
+        import time
+
+        while True:
+            start = time.monotonic()
+            logs = await self.process_logs()
+            await self.analyze(logs)
+            cycle = time.monotonic() - start
+            await self.metrics.set_cycle_time(cycle)
+            await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- track HTTP 429 responses and worker cycle duration
- expose async helpers in MetricsCollector
- update Gemini error handling to increment 429 counter
- measure worker cycle time in ThreatHunterCore
- start periodic worker from core in startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688112eb626c83299b4d79ad4690ea6c