### PR TITLE
Async FAISS operations with dedup

### DIFF
--- a/threat_hunter/core/threat_hunter_core.py
+++ b/threat_hunter/core/threat_hunter_core.py
@@ -65,8 +65,8 @@ class ThreatHunterCore:
         self.status = "processing"
         logs = await self.wazuh.read_new_logs()
         if logs:
-            self.vector_db.add_documents(logs)
-            self.vector_db.save()
+            await self.vector_db.add_documents(logs)
+            await self.vector_db.save()
             self._save_state()
         self.status = "ready"
         self.last_run = datetime.utcnow().isoformat()

--- a/threat_hunter/core/vector_db.py
+++ b/threat_hunter/core/vector_db.py
@@ -1,6 +1,7 @@
 import json
 import os
 import hashlib
+import asyncio
 from typing import List, Dict, Any
 
 import faiss
@@ -18,31 +19,36 @@ class VectorDB:
         os.makedirs(db_dir, exist_ok=True)
         self.index_path = os.path.join(db_dir, "vectors.faiss")
         self.meta_path = os.path.join(db_dir, "metadata.json")
+        self.lock = asyncio.Lock()
         self.model = SentenceTransformer("all-MiniLM-L6-v2")
         self.index = faiss.IndexFlatL2(self.model.get_sentence_embedding_dimension())
         self.index = faiss.IndexIDMap(self.index)
         self.metadata: Dict[int, Dict[str, Any]] = {}
         if os.path.exists(self.index_path):
-            self.load()
+            asyncio.run(self.load())
 
-    def save(self) -> None:
-        faiss.write_index(self.index, self.index_path)
+    async def save(self) -> None:
+        async with self.lock:
+            faiss.write_index(self.index, self.index_path)
         with open(self.meta_path, "w") as f:
             json.dump(self.metadata, f)
         logger.info("Vector database saved")
 
-    def load(self) -> None:
-        self.index = faiss.read_index(self.index_path)
-        self.index = faiss.IndexIDMap(self.index)
+    async def load(self) -> None:
+        async with self.lock:
+            self.index = faiss.read_index(self.index_path)
+            self.index = faiss.IndexIDMap(self.index)
         with open(self.meta_path, "r") as f:
             self.metadata = {int(k): v for k, v in json.load(f).items()}
         logger.info("Vector database loaded (%d vectors)", self.index.ntotal)
 
-    def add_documents(self, docs: List[Dict[str, Any]]):
+    async def add_documents(self, docs: List[Dict[str, Any]]):
         if not docs:
             return
         texts = [json.dumps(doc, sort_keys=True) for doc in docs]
-        embeddings = self.model.encode(texts, convert_to_numpy=True)
+        embeddings = await asyncio.to_thread(
+            self.model.encode, texts, convert_to_numpy=True
+        )
         ids = []
         new_docs = []
         for emb, doc in zip(embeddings, docs):
@@ -52,18 +58,28 @@ class VectorDB:
                 continue
             ids.append(np.int64(doc_id))
             new_docs.append(emb)
-            self.metadata[doc_id] = doc
+            meta = dict(doc)
+            meta["sha256"] = sha
+            meta["faiss_id"] = doc_id
+            self.metadata[doc_id] = meta
         if new_docs:
-            self.index.add_with_ids(np.vstack(new_docs), np.array(ids))
+            async with self.lock:
+                self.index.add_with_ids(np.vstack(new_docs), np.array(ids))
             logger.info("Added %d documents to vector DB", len(new_docs))
 
-    def search(self, query: str, k: int = 5) -> List[Dict[str, Any]]:
+    async def search(self, query: str, k: int = 5) -> List[Dict[str, Any]]:
         if self.index.ntotal == 0:
             return []
-        q_emb = self.model.encode([query], convert_to_numpy=True)
-        distances, ids = self.index.search(q_emb, k)
+        q_emb = await asyncio.to_thread(
+            self.model.encode, [query], convert_to_numpy=True
+        )
+        async with self.lock:
+            distances, ids = self.index.search(q_emb, k)
         results = []
-        for i in ids[0]:
-            if i in self.metadata:
-                results.append(self.metadata[i])
+        for dist, idx in zip(distances[0], ids[0]):
+            if idx in self.metadata:
+                results.append({
+                    "distance": float(dist),
+                    "metadata": self.metadata[idx],
+                })
         return results


### PR DESCRIPTION
## Summary
- lock FAISS index operations with an `asyncio.Lock`
- deduplicate documents using SHA256 and store `sha256` and `faiss_id`
- update search to include distance scores
- await vector DB operations in `ThreatHunterCore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688112ec76fc83298cdfbc83a81ad545