### PR TITLE
Add configurable log batch reading to Wazuh

### DIFF
--- a/threat_hunter/settings.py
+++ b/threat_hunter/settings.py
@@ -12,7 +12,14 @@ def get_threat_hunter_core() -> ThreatHunterCore:
     wazuh_user = os.environ.get("WAZUH_API_USER", "wazuh")
     wazuh_password = os.environ.get("WAZUH_API_PASSWORD", "wazuh")
     log_file = os.environ.get("WAZUH_LOG_FILE", "/var/ossec/logs/alerts/alerts.json")
+    batch_size = int(os.environ.get("WAZUH_BATCH_SIZE", "1000"))
     db_dir = os.environ.get("THREAT_DB_DIR", "./db")
 
-    wazuh_api = WazuhAPI(wazuh_base_url, wazuh_user, wazuh_password, log_file)
+    wazuh_api = WazuhAPI(
+        wazuh_base_url,
+        wazuh_user,
+        wazuh_password,
+        log_file,
+        batch_size=batch_size,
+    )
     return ThreatHunterCore(api_keys=api_keys, wazuh_api=wazuh_api, db_dir=db_dir)


### PR DESCRIPTION
## Summary
- persist reader position in a `.pos` file and reset if file shrinks
- make Wazuh log batch size configurable and expose through settings
- ensure position resets and configurable batch size are used when processing logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688112ed143c8329a749b1c6c0c76ab4