### PR TITLE
Add persistent settings support

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,13 +39,11 @@ async def startup_event():
     global core
     core = get_threat_hunter_core()
 
-    interval = int(os.environ.get("PROCESS_INTERVAL", 300))
-
     async def periodic():
         while True:
             logs = await core.process_logs()
             await core.analyze(logs)
-            await asyncio.sleep(interval)
+            await asyncio.sleep(core.settings.get("processing_interval", 300))
 
     asyncio.create_task(periodic())
 

--- a/threat_hunter/api/chat.py
+++ b/threat_hunter/api/chat.py
@@ -25,5 +25,8 @@ async def execute_chat(
     query: ChatQuery,
     core: ThreatHunterCore = Depends(get_threat_hunter_core),
 ):
-    answer = await core.gemini.generate(query.query, max_tokens=256)
+    answer = await core.gemini.generate(
+        query.query,
+        max_tokens=core.settings.get("max_output_tokens", 256),
+    )
     return {"answer": answer}

--- a/threat_hunter/static/js/main.js
+++ b/threat_hunter/static/js/main.js
@@ -1214,4 +1214,53 @@ document.addEventListener('DOMContentLoaded', () => {
     // Click handlers for opening modals
     document.getElementById('security-issues-header').addEventListener('click', () => openFullIssuesModal(allIssues));
     document.getElementById('rule-chart-card').addEventListener('click', () => openRuleAnalysisModal());
+
+    // Settings form
+    async function loadSettings() {
+        try {
+            const res = await fetch('/api/settings');
+            if (!res.ok) return;
+            const data = await res.json();
+            for (const [k, v] of Object.entries(data)) {
+                const el = document.querySelector(`#settings-form [name="${k}"]`);
+                if (el) el.value = v;
+            }
+        } catch (e) { console.error('Failed to load settings', e); }
+    }
+
+    document.getElementById('settings-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const data = Object.fromEntries(new FormData(form).entries());
+        for (const k in data) data[k] = parseInt(data[k], 10);
+        try {
+            const res = await fetch('/api/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (!res.ok) throw new Error('Save failed');
+            showToast('Settings saved');
+            settingsModal.style.display = 'none';
+            fetchData();
+        } catch (err) {
+            console.error(err);
+            showToast('Failed to save settings', 'error');
+        }
+    });
+
+    document.getElementById('clear-db-btn').addEventListener('click', async () => {
+        if (!confirm('Clear all stored data?')) return;
+        try {
+            const res = await fetch('/api/clear_db', { method: 'POST' });
+            if (!res.ok) throw new Error('Clear failed');
+            showToast('Database cleared');
+            fetchData();
+        } catch (err) {
+            console.error(err);
+            showToast('Failed to clear database', 'error');
+        }
+    });
+
+    loadSettings();
 });


### PR DESCRIPTION
## Summary
- add persistent settings store in `ThreatHunterCore`
- expose `/api/settings` and `/api/clear_db` endpoints
- use settings in worker loop and Gemini calls
- enable settings form actions on frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688112edb2a08329ba2dced13b22f3a9