### PR TITLE
Extend dashboard metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import uvicorn
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import PlainTextResponse
 
 from threat_hunter.api import dashboard, chat, issues, logs
 from threat_hunter.settings import get_threat_hunter_core
@@ -53,8 +54,9 @@ async def startup_event():
 @app.get("/metrics")
 async def metrics_endpoint():
     if core:
-        return await core.get_metrics_text()
-    return ""
+        text = await core.metrics.render()
+        return PlainTextResponse(text)
+    return PlainTextResponse("")
 
 
 if __name__ == "__main__":

--- a/threat_hunter/static/js/main.js
+++ b/threat_hunter/static/js/main.js
@@ -451,8 +451,9 @@ async function updateUI(data) {
     document.getElementById('active-api-key').textContent = `Key ${(data.active_api_key_index || 0) + 1}`;
     
     // Update application status and handle countdown
-    const status = data.status || 'Unknown';
-    document.getElementById('app-status').textContent = status;
+    const rawStatus = data.status || 'Unknown';
+    const statusLower = rawStatus.toLowerCase();
+    document.getElementById('app-status').textContent = rawStatus.charAt(0).toUpperCase() + rawStatus.slice(1);
     
     // Update processing interval and start countdown if idle/ready
     if (data.settings && data.settings.processing_interval) {
@@ -461,7 +462,7 @@ async function updateUI(data) {
     
     if (data.last_run) {
         lastUpdateTime = new Date(data.last_run).getTime();
-        if (status === 'Ready' || status === 'Idle') {
+        if (statusLower === 'ready' || statusLower === 'idle') {
             startCountdownTimer();
         } else {
             document.getElementById('countdown-container').style.display = 'none';


### PR DESCRIPTION
## Summary
- add plaintext metrics endpoint
- compute and expose log trend and rule distribution
- show countdown timer based on server status

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688112ef35f88329889b34872ecd7b77